### PR TITLE
docs: Add copy to clipboard to code snippet

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -80,12 +80,15 @@
               "node_modules/@fortawesome/fontawesome-free/css/all.css",
               "node_modules/bulma/css/bulma.css",
               "node_modules/prism-themes/themes/prism-material-light.css",
-              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.css"
+              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.css",
+              "node_modules/prismjs/plugins/toolbar/prism-toolbar.css"
             ],
             "scripts": [
               "node_modules/marked/lib/marked.js",
               "node_modules/prismjs/prism.js",
-              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js"
+              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.js",
+              "node_modules/prismjs/plugins/toolbar/prism-toolbar.min.js",
+              "node_modules/prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js"
             ]
           },
           "configurations": {

--- a/projects/bulma-app/src/styles.scss
+++ b/projects/bulma-app/src/styles.scss
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 
 body {
-  font-family: Roboto, "Helvetica Neue", sans-serif;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
 .parent-container {
@@ -69,4 +69,20 @@ body {
   color: #7a7a7a;
   display: block;
   font-size: 1.25rem;
+}
+
+/** copy to clipboard button css */
+
+div.code-toolbar > .toolbar {
+  opacity: unset !important;
+  top: 0.5em !important;
+  right: 0.5em !important;
+}
+
+div.code-toolbar > .toolbar button {
+  color: white !important;
+  background-color: black !important;
+  padding: 4px !important;
+  font-size: 15px !important;
+  cursor: pointer !important;
 }


### PR DESCRIPTION
PrismJS provides copy-to-clipboard plugin by default. We just need to declare it in `angular.json`. The provided CSS file needed to be updated to suit the theme.

![Screenshot](https://user-images.githubusercontent.com/43369891/105626274-9bdabe80-5e54-11eb-80b4-97a524d07709.png)

Closes #293 maybe?